### PR TITLE
chore(tsc): declaration enable in `cjs`

### DIFF
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,7 +3,5 @@
   "compilerOptions": {
     "module": "esnext",
     "outDir": "dist/esm",
-    "declaration": true,
-    "declarationMap": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "lib": ["dom"],
     "types": ["node", "jest"],
     "jsx": "react-jsx",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
Fixed missing type in the following example.

```tsx
// `RecoilURLSyncJSONNext` type not found
import { RecoilURLSyncJSONNext } from 'recoil-sync-next'
```