### PR TITLE
chore: add github token variable on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with: 
           package-manager: 'yarn'
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Change `github-token` variable from default.
https://www.covbot.dev/
https://github.com/ArtiomTr/jest-coverage-report-action/blob/main/action.yml#L11