### PR TITLE
fix: swc minify bug avoidance, update compile target

### DIFF
--- a/examples/history-sync-json/next.config.js
+++ b/examples/history-sync-json/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: false,
+  swcMinify: true,
   experimental: {
     scrollRestoration: true,
     newNextLinkBehavior: true,

--- a/examples/history-sync-json/tsconfig.json
+++ b/examples/history-sync-json/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/examples/url-sync-json/tsconfig.json
+++ b/examples/url-sync-json/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2018",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
## Overview

Cannot restore values other than the last updated value in `examples/history-sync-json` in production build and reloading.

### cause

My guess is that it is probably a bug in the swc.

_no_minify_
<img width="654" alt="no_minify" src="https://user-images.githubusercontent.com/25711332/179118176-ac02f40d-3d99-4fba-a3c1-74acadc079cb.png">

_minify_
<img width="604" alt="minify" src="https://user-images.githubusercontent.com/25711332/179118192-c27eec1c-5e0a-44ad-9a57-91caf7d55ad0.png">


## demo
There is a possibility to delete the .next cache or else it won't work.

```sh
$ yarn build
$ cd examples/history-sync-json
$ rm -rf .next
$ yarn build
$ yarn start
```