### PR TITLE
examples(RHF): support for default{Value,Checked} & useFieldArray

### DIFF
--- a/examples/react-hook-form/pages/form/[index].tsx
+++ b/examples/react-hook-form/pages/form/[index].tsx
@@ -11,10 +11,13 @@ import styles from '../../styles/form.module.css'
 type FormState = {
   name: string
   comment: string
-  radio: string
-  checkbox: readonly string[]
+  time: string
+  selectedRadio: string
+  selectedCheckbox: readonly string[]
   items: readonly {
     value: string
+    radio: string
+    checkbox: string
   }[]
 }
 
@@ -25,11 +28,14 @@ const formState = initializableAtom<FormState>({
       refine: object({
         name: string(),
         comment: string(),
-        radio: string(),
-        checkbox: array(string()),
+        time: string(),
+        selectedRadio: string(),
+        selectedCheckbox: array(string()),
         items: array(
           object({
             value: string(),
+            radio: string(),
+            checkbox: string(),
           })
         ),
       }),
@@ -37,17 +43,12 @@ const formState = initializableAtom<FormState>({
   ],
 })
 
-const initialState: FormState = {
-  name: 'a',
-  comment: 'b',
-  radio: '1',
-  checkbox: ['1'],
-  items: [{ value: '1' }, { value: '2' }],
-}
-
-const emptyItem: FormState['items'][number] = {
+let count = 1
+const createNewItem = (): FormState['items'][number] => ({
   value: '',
-}
+  radio: `${count}`,
+  checkbox: `${count++}`,
+})
 
 const Form: NextPage<FormState> = (props) => {
   // check render
@@ -94,9 +95,13 @@ const Form: NextPage<FormState> = (props) => {
             <dd>
               <input type="text" {...registerWithDefaultValue('comment')} />
             </dd>
+            <dt>time</dt>
+            <dd>
+              <input type="text" {...registerWithDefaultValue('time')} />
+            </dd>
             <dt>items</dt>
             <dd>
-              <button type="button" onClick={() => prepend(emptyItem)}>
+              <button type="button" onClick={() => prepend(createNewItem())}>
                 Prepend
               </button>
               <ul>
@@ -105,13 +110,16 @@ const Form: NextPage<FormState> = (props) => {
                     <span>{index} </span>
                     <input
                       type="radio"
-                      {...registerWithDefaultChecked('radio', `${index + 1}`)}
+                      {...registerWithDefaultChecked(
+                        'selectedRadio',
+                        field.radio
+                      )}
                     />
                     <input
                       type="checkbox"
                       {...registerWithDefaultChecked(
-                        'checkbox',
-                        `${index + 1}`
+                        'selectedCheckbox',
+                        field.checkbox
                       )}
                     />
                     <input
@@ -121,13 +129,13 @@ const Form: NextPage<FormState> = (props) => {
                     />
                     <button
                       type="button"
-                      onClick={() => insert(index, emptyItem)}
+                      onClick={() => insert(index, createNewItem())}
                     >
                       Insert before
                     </button>
                     <button
                       type="button"
-                      onClick={() => insert(index + 1, emptyItem)}
+                      onClick={() => insert(index + 1, createNewItem())}
                     >
                       Insert after
                     </button>
@@ -147,7 +155,7 @@ const Form: NextPage<FormState> = (props) => {
                   </li>
                 ))}
               </ul>
-              <button type="button" onClick={() => append(emptyItem)}>
+              <button type="button" onClick={() => append(createNewItem())}>
                 Append
               </button>
             </dd>
@@ -168,6 +176,16 @@ export const getServerSideProps: GetServerSideProps<FormState> = async ({
   params,
 }) => {
   return {
-    props: initialState,
+    props: {
+      name: 'a',
+      comment: 'b',
+      time: new Date().toLocaleTimeString(),
+      selectedRadio: 'A',
+      selectedCheckbox: ['A'],
+      items: [
+        { value: '', radio: 'A', checkbox: 'A' },
+        { value: '', radio: 'B', checkbox: 'B' },
+      ],
+    },
   }
 }

--- a/examples/react-hook-form/pages/form/[index].tsx
+++ b/examples/react-hook-form/pages/form/[index].tsx
@@ -11,6 +11,8 @@ import styles from '../../styles/form.module.css'
 type FormState = {
   name: string
   comment: string
+  radio: string
+  checkbox: readonly string[]
   items: readonly {
     value: string
   }[]
@@ -23,6 +25,8 @@ const formState = initializableAtom<FormState>({
       refine: object({
         name: string(),
         comment: string(),
+        radio: string(),
+        checkbox: array(string()),
         items: array(
           object({
             value: string(),
@@ -33,9 +37,11 @@ const formState = initializableAtom<FormState>({
   ],
 })
 
-const initialState = {
+const initialState: FormState = {
   name: 'a',
   comment: 'b',
+  radio: '1',
+  checkbox: ['1'],
   items: [{ value: '1' }, { value: '2' }],
 }
 
@@ -50,6 +56,7 @@ const Form: NextPage<FormState> = (props) => {
   const {
     control,
     registerWithDefaultValue,
+    registerWithDefaultChecked,
     onChangeForm,
     handleSubmit,
     reset,
@@ -96,6 +103,17 @@ const Form: NextPage<FormState> = (props) => {
                 {fields.map((field, index) => (
                   <li key={field.id}>
                     <span>{index} </span>
+                    <input
+                      type="radio"
+                      {...registerWithDefaultChecked('radio', `${index + 1}`)}
+                    />
+                    <input
+                      type="checkbox"
+                      {...registerWithDefaultChecked(
+                        'checkbox',
+                        `${index + 1}`
+                      )}
+                    />
                     <input
                       {...registerWithDefaultValue(
                         `items.${index}.value` as const

--- a/examples/react-hook-form/src/hooks/useFormSync.ts
+++ b/examples/react-hook-form/src/hooks/useFormSync.ts
@@ -117,7 +117,7 @@ export function useFormSync<TFieldValues extends FieldValues, TContext = any>(
   const resetState = useResetRecoilState(formState)
   const reset = useCallback(() => {
     resetState()
-    resetForm(getDefaultValues())
+    resetForm(structuredClone(getDefaultValues()))
   }, [getDefaultValues, resetForm, resetState])
 
   const setFormValues = useSetRecoilState(formState)

--- a/examples/react-hook-form/src/hooks/useFormSync.ts
+++ b/examples/react-hook-form/src/hooks/useFormSync.ts
@@ -2,8 +2,23 @@ import { useCallback, useRef } from 'react'
 import {
   DeepPartial,
   FieldValues,
+  InternalFieldName,
+  Resolver,
+  useFieldArray,
+  UseFieldArrayAppend,
+  UseFieldArrayInsert,
+  UseFieldArrayMove,
+  UseFieldArrayPrepend,
+  UseFieldArrayProps,
+  UseFieldArrayRemove,
+  UseFieldArrayReplace,
+  UseFieldArrayReturn,
+  UseFieldArraySwap,
+  UseFieldArrayUpdate,
   useForm,
   UseFormProps,
+  UseFormRegister,
+  UseFormRegisterReturn,
   UseFormReturn,
 } from 'react-hook-form'
 import {
@@ -16,7 +31,15 @@ import {
 type UseFormSyncReturn<
   TFieldValues extends FieldValues,
   TContext = any
-> = UseFormReturn<TFieldValues, TContext> & { onChangeForm: () => void }
+> = UseFormReturn<TFieldValues, TContext> & {
+  registerWithDefaultValue: UseFormRegister<TFieldValues>
+  onChangeForm: () => void
+  useFieldArraySync: (
+    props: UseFieldArrayProps<TFieldValues>
+  ) => UseFieldArrayReturn<TFieldValues>
+}
+
+const FIELD_ARRAY_NAME_PATTERN = /([^.]+)\.([0-9]+)\.([^.]+)/
 
 export function useFormSync<TFieldValues extends FieldValues, TContext = any>(
   formState: RecoilState<TFieldValues>,
@@ -37,6 +60,7 @@ export function useFormSync<TFieldValues extends FieldValues, TContext = any>(
   defaultValuesRef.current ??= getDefaultValues()
 
   const {
+    register,
     getValues,
     reset: resetForm,
     ...rest
@@ -47,10 +71,17 @@ export function useFormSync<TFieldValues extends FieldValues, TContext = any>(
     defaultValues: defaultValuesRef.current as DeepPartial<TFieldValues>,
   })
 
-  const setFormValues = useSetRecoilState(formState)
-  const onChangeForm = useCallback(() => {
-    setFormValues(getValues())
-  }, [setFormValues, getValues])
+  const registerWithDefaultValue: UseFormRegister<TFieldValues> = useCallback(
+    (name, options) => {
+      const defaultValues = defaultValuesRef.current!
+      const names = FIELD_ARRAY_NAME_PATTERN.exec(name)
+      const defaultValue = names
+        ? defaultValues[names[1]]?.[+names[2]]?.[names[3]]
+        : defaultValues[name]
+      return { ...register(name, options), defaultValue }
+    },
+    [register]
+  )
 
   const resetState = useResetRecoilState(formState)
   const reset = useCallback(() => {
@@ -58,5 +89,72 @@ export function useFormSync<TFieldValues extends FieldValues, TContext = any>(
     resetForm(getDefaultValues())
   }, [getDefaultValues, resetForm, resetState])
 
-  return { ...rest, getValues, reset, onChangeForm }
+  const setFormValues = useSetRecoilState(formState)
+  const onChangeForm = useCallback(() => {
+    setFormValues(structuredClone(getValues()))
+  }, [setFormValues, getValues])
+
+  const useFieldArraySync = (
+    props: UseFieldArrayProps<TFieldValues>
+  ): UseFieldArrayReturn<TFieldValues> => {
+    const origin = useFieldArray(props)
+    const swap: UseFieldArraySwap = (indexA, indexB) => {
+      origin.swap(indexA, indexB)
+      onChangeForm()
+    }
+    const move: UseFieldArrayMove = (indexA, indexB) => {
+      origin.move(indexA, indexB)
+      onChangeForm()
+    }
+    const prepend: UseFieldArrayPrepend<TFieldValues> = (value, options) => {
+      origin.prepend(value, options)
+      onChangeForm()
+    }
+    const append: UseFieldArrayAppend<TFieldValues> = (value, options) => {
+      origin.append(value, options)
+      onChangeForm()
+    }
+    const remove: UseFieldArrayRemove = (index) => {
+      origin.remove(index)
+      onChangeForm()
+    }
+    const insert: UseFieldArrayInsert<TFieldValues> = (
+      index,
+      value,
+      options
+    ) => {
+      origin.insert(index, value, options)
+      onChangeForm()
+    }
+    const update: UseFieldArrayUpdate<TFieldValues> = (index, value) => {
+      origin.update(index, value)
+      onChangeForm()
+    }
+    const replace: UseFieldArrayReplace<TFieldValues> = (value) => {
+      origin.replace(value)
+      onChangeForm()
+    }
+
+    return {
+      swap,
+      move,
+      prepend,
+      append,
+      remove,
+      insert,
+      update,
+      replace,
+      fields: origin.fields,
+    }
+  }
+
+  return {
+    ...rest,
+    register,
+    registerWithDefaultValue,
+    getValues,
+    reset,
+    onChangeForm,
+    useFieldArraySync,
+  }
 }


### PR DESCRIPTION
### Support for `defaultValue`

Use `registerWithDefaultValue` instead of `register`:
```
const { registerWithDefaultValue, ... } = useFormSync<FormState>(formState({ name: 'Foo' }))
...
  <input type="text" {...registerWithDefaultValue('name')} />
```

Even SSR/SSG, it is rendered with default values.

### Support for `defaultChecked`

Use `registerWithDefaultChecked` instead of `register`
```
const { registerWithDefaultChecked, ... } = useFormSync<FormState>(formState({
  selectOne: '1', // for radio
  selectMany: ['1', '2'], // for checkbox
}))
...
  <input type="radio" {...registerWithDefaultChecked('selectOne', '1') /* defaults to checked */} />
  <input type="radio" {...registerWithDefaultChecked('selectOne', '2') /* defaults to not checked */} />
  <input type="radio" {...registerWithDefaultChecked('selectOne', '3') /* defaults to not checked */} />

  <input type="checkbox" {...registerWithDefaultChecked('selectMany', '1') /* defaults to checked */} />
  <input type="checkbox" {...registerWithDefaultChecked('selectMany', '2') /* defaults to checked */} />
  <input type="checkbox" {...registerWithDefaultChecked('selectMany', '3') /* defaults to not checked */} />
```

### Support for useFieldArray

Use `useFieldArraySync` returns from `useFormSync` instead of `useFieldArray`:
```
const { useFieldArraySync, control, ... } = useFormSync<FormState>(formState({items: [{value: 1}, {value: 2}] })
const { fields, ...} = useFieldArraySync({ control, name: 'items' })
...
  {fields.map((field, index) => (
    <input key={field.id} {...register(`items.${index}.value` as const)} />
  ))}
```

Of course, it is possible to use `registerWithDefaultValue` instead of `register`.