### PR TITLE
Expose RecoilURLSyncNext

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './history/RecoilHistorySyncJSONNext'
 export * from './history/RecoilHistorySyncTransitNext'
 export * from './url/RecoilURLSyncJSONNext'
+export * from './url/RecoilURLSyncNext'
 export * from './url/RecoilURLSyncTransitNext'
 export * from './utils/initializableAtom'
 export * from './utils/initializableAtomFamily'


### PR DESCRIPTION
RecoilURLSyncNext is mentioned in the README, but is not exposed properly. Without this, I cannot use RecoilURLSyncNext in my application.